### PR TITLE
Add log api to localfs driver

### DIFF
--- a/localfs.js
+++ b/localfs.js
@@ -45,7 +45,7 @@ function createUserDirIfNeeded(rootDir, id) {
     console.log("creating userDir", userDir)
     fs.mkdirSync(userDir)
     fs.mkdirSync(path.join(userDir, "node_modules"))
-    fs.writeFileSync(path.join(userDir, "package.json"), 
+    fs.writeFileSync(path.join(userDir, "package.json"),
       '{\n"name": "node-red-project",\n"description": "A Node-RED Project",\n"version": "0.0.1",\n"private": true\n }'
       )
   } else {
@@ -204,7 +204,7 @@ module.exports = {
     var port = options.port || getNextFreePort(this._usedPorts);
 
     this._usedPorts.push(port);
-    
+
     let pid = startProject(id, options, directory, port)
     console.log("PID",pid, "port", port, "directory", directory)
 
@@ -297,7 +297,7 @@ module.exports = {
     // } else {
     //   return Promise.resolve()
     // }
-    
+
   },
   /**
    * Returns the settings for the project
@@ -312,7 +312,7 @@ module.exports = {
       settings.userDir = id
       settings.port = project.port
       settings.settings = "module.exports = { "
-        + "flowFile: 'flows.json', " 
+        + "flowFile: 'flows.json', "
         + "flowFilePretty: true, "
         + "adminAuth: require('@flowforge/nr-auth')({ "
         + " baseURL: 'http://localhost:" + project.port + "', "
@@ -323,7 +323,7 @@ module.exports = {
         + "storageModule: require('@flowforge/nr-storage'), "
         + "httpStorage: { "
         + "projectID: '" + id + "', "
-        + "baseURL: '" + options.storageURL + "', " 
+        + "baseURL: '" + options.storageURL + "', "
         + "token: '" + options.projectToken + "', "
         + " }, "
         + "logging: { "
@@ -411,5 +411,16 @@ module.exports = {
     })
 
     return {state: "okay"}
+  },
+
+  /**
+   * Get a Project's logs
+   * @param {string} id - id of project
+   * @return {array} logs
+   */
+  logs: async (id) => {
+    let project = await this._app.db.models.LocalFSProject.byId(id)
+    let result = await got.get("http://localhost:" + (project.port + 1000) + "/flowforge/logs").json()
+    return result;
   }
 }


### PR DESCRIPTION
Adds a `logs` function to the localfs driver to retrieve the logs for a given project.

This currently does *no* filtering or pagination - it returns everything it can get. The pagination is handled in the core forge app (separate PR).

There is another PR incoming for `flowforge-nr-launcher` 