### PR TITLE
Add support for privateCA config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,19 @@ This will start/stop/monitor Node-RED instances and build separate useDirs for e
 
 ## Configure
 
-The following environment variables (in the `.env` file) configure this driver
+In the `flowforge.yml` file the following options can be set under the `drive.options` section
 
- - CONTAINER_DRIVER=localfs
- - LOCALFS_ROOT=<path/to/store/project/userDirs>
- - LOCALFS_START_PORT=12080
- - LOCALFS_NODE_PATH=<path/to/node/binary> (not required, but useful with nvm)
+```yaml
+...
+driver:
+  type: localfs
+  options:
+    start_port: 12080
+    privateCA: /full/path/to/chain.pem
+```
+
+ - `start_port` Port number to start from when creating Instances (default: 12080)
+ - `privateCA` is a fully qaulified path to a pem file containing trusted CA cert chain (default: not set)
 
 ## Node-RED Versions for Stacks
 

--- a/localfs.js
+++ b/localfs.js
@@ -78,6 +78,11 @@ async function startProject (app, project, ProjectStack, userDir, port) {
         env.PATH = process.env.PATH
     }
 
+    //fully qualified path to ca.pem file
+    if (app.config.driver.options.privateCA && fs.existsSync(this._app.config.driver.options.privateCA)) {
+        env.NODE_EXTRA_CA_CERTS = app.config.driver.options.privateCA
+    }
+
     logger.debug(`Stack info ${JSON.stringify(ProjectStack?.properties)}`)
     /*
      * ProjectStack.properties will contain the stack properties for this project

--- a/localfs.js
+++ b/localfs.js
@@ -78,7 +78,7 @@ async function startProject (app, project, ProjectStack, userDir, port) {
         env.PATH = process.env.PATH
     }
 
-    //fully qualified path to ca.pem file
+    // fully qualified path to ca.pem file
     if (app.config.driver.options.privateCA && fs.existsSync(this._app.config.driver.options.privateCA)) {
         env.NODE_EXTRA_CA_CERTS = app.config.driver.options.privateCA
     }


### PR DESCRIPTION
Feature parity with docker and k8s drivers

## Description

<!-- Describe your changes in detail -->
Add support for specifying a set of extra trusted CA certificates

Matches support in K8s and Docker.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

