### PR TITLE
Ensure userDir/storage is created

### DIFF
--- a/localfs.js
+++ b/localfs.js
@@ -36,6 +36,7 @@ async function createUserDirIfNeeded (userDir) {
         logger.info(`Creating settings directory: ${userDir}`)
         await fs.mkdir(userDir)
         await fs.mkdir(path.join(userDir, 'node_modules'))
+        await fs.mkdir(path.join(userDir), 'storage')
         const packageJSON = {
             name: 'flowfuse-node-red-project',
             description: 'A FlowFuse Node-RED Instance',
@@ -45,6 +46,9 @@ async function createUserDirIfNeeded (userDir) {
         await fs.writeFile(path.join(userDir, 'package.json'),
             JSON.stringify(packageJSON)
         )
+    }
+    if (!existsSync(path.join(userDir), 'storage')) {
+        await fs.mkdir(path.join(userDir), 'storage')
     }
 }
 

--- a/localfs.js
+++ b/localfs.js
@@ -47,6 +47,7 @@ async function createUserDirIfNeeded (userDir) {
             JSON.stringify(packageJSON)
         )
     }
+    // "upgrade" exiting projects
     if (!existsSync(path.join(userDir), 'storage')) {
         await fs.mkdir(path.join(userDir), 'storage')
     }

--- a/localfs.js
+++ b/localfs.js
@@ -36,7 +36,7 @@ async function createUserDirIfNeeded (userDir) {
         logger.info(`Creating settings directory: ${userDir}`)
         await fs.mkdir(userDir)
         await fs.mkdir(path.join(userDir, 'node_modules'))
-        await fs.mkdir(path.join(userDir), 'storage')
+        await fs.mkdir(path.join(userDir, 'storage'))
         const packageJSON = {
             name: 'flowfuse-node-red-project',
             description: 'A FlowFuse Node-RED Instance',
@@ -48,8 +48,8 @@ async function createUserDirIfNeeded (userDir) {
         )
     }
     // "upgrade" exiting projects
-    if (!existsSync(path.join(userDir), 'storage')) {
-        await fs.mkdir(path.join(userDir), 'storage')
+    if (!existsSync(path.join(userDir, 'storage'))) {
+        await fs.mkdir(path.join(userDir, 'storage'))
     }
 }
 


### PR DESCRIPTION
part of FlowFuse/flowfuse#3056
## Description

<!-- Describe your changes in detail -->
This is needed for the Persistent Storage changes.

Must be merged before https://github.com/FlowFuse/nr-launcher/pull/250

This is so that nr-launcher 

## Related Issue(s)
FlowFuse/flowfuse#3056

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

