### PR TITLE
Update release publish to use NodeJS v18

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - run: npm ci --omit=dev
       - uses: JS-DevTools/npm-publish@v3
         with:


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Update build to run on NodeJS 18

There is no .npmignore file in this project so safe to update