### PR TITLE
Skip the team broker when checking to restart agents

### DIFF
--- a/localfs.js
+++ b/localfs.js
@@ -229,7 +229,7 @@ async function getMQTTAgentList (driver) {
     })
 
     agents.forEach(async (agent) => {
-        if (agent.settings.port) {
+        if (agent.Team && agent.settings.port) {
             driver._usedAgentPorts.add(agent.settings.port)
         }
     })
@@ -285,19 +285,21 @@ async function checkExistingMQTTAgents (driver) {
     const brokers = await getMQTTAgentList(driver)
 
     brokers.forEach(async (broker) => {
-        if (broker.state !== 'running') {
-            return
-        }
+        if (broker.Team) {
+            if (broker.state !== 'running') {
+                return
+            }
 
-        try {
-            await got.get(`http://localhost:${broker.settings.port}/healthz`, {
-                timeout: {
-                    request: 1000
-                }
-            }).json()
-        } catch (err) {
-            logger.info(`Starting MQTT Agent ${broker.hashid} on port ${broker.settings.port}`)
-            launchMQTTAgent(broker, driver)
+            try {
+                await got.get(`http://localhost:${broker.settings.port}/healthz`, {
+                    timeout: {
+                        request: 1000
+                    }
+                }).json()
+            } catch (err) {
+                logger.info(`Starting MQTT Agent ${broker.hashid} on port ${broker.settings.port}`)
+                launchMQTTAgent(broker, driver)
+            }
         }
     })
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
The driver needs to skip the place holder "team-broker" entry in the database

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

