### PR TITLE
Add historical CPU/process size API

### DIFF
--- a/localfs.js
+++ b/localfs.js
@@ -805,5 +805,13 @@ module.exports = {
                 console.log(err)
             }
         }
+    },
+    resources: async (project) => {
+        if (this._projects[project.id] === undefined) {
+            throw new Error('Cannot get instance resources')
+        }
+        const port = await project.getSetting('port')
+        const result = await got.get('http://localhost:' + (port + 1000) + '/flowforge/resources').json()
+        return result
     }
 }

--- a/localfs.js
+++ b/localfs.js
@@ -812,6 +812,14 @@ module.exports = {
         }
         const port = await project.getSetting('port')
         const result = await got.get('http://localhost:' + (port + 1000) + '/flowforge/resources').json()
-        return result
+        if (Array.isArray(result)) {
+            return {
+                meta: {},
+                resources: result,
+                count: result.length
+            }
+        } else {
+            return result
+        }
     }
 }

--- a/localfs.js
+++ b/localfs.js
@@ -19,7 +19,6 @@ const semver = require('semver')
 const childProcess = require('child_process')
 const { WebSocket } = require('ws')
 
-
 let initialPortNumber
 let initialAgentPortNumber
 
@@ -830,7 +829,6 @@ module.exports = {
         }
         const port = await project.getSetting('port')
         const url = 'ws://localhost:' + (port + 1000) + '/flowforge/resources'
-        
         const resourceStream = new WebSocket(url, {})
         // resourceStream.on('open', () => {
         //     console.log('Resource stream opened')

--- a/localfs.js
+++ b/localfs.js
@@ -830,11 +830,7 @@ module.exports = {
         const port = await project.getSetting('port')
         const url = 'ws://localhost:' + (port + 1000) + '/flowforge/resources'
         const resourceStream = new WebSocket(url, {})
-        // resourceStream.on('open', () => {
-        //     console.log('Resource stream opened')
-        // })
         resourceStream.on('message', (data) => {
-            // console.log('Received resource stream message', data)
             socket.send(data)
         })
         resourceStream.on('error', (err) => {
@@ -842,11 +838,10 @@ module.exports = {
             socket.close()
         })
         socket.on('close', () => {
-            // console.log('Closing resource stream')
             try {
                 resourceStream.close()
-            } catch (err) {
-                // logger.error(`Error closing resource stream: ${err}`)
+            } catch (_err) {
+                // ignore error
             }
         })
         return resourceStream

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@flowfuse/nr-launcher": "^2.17.0",
                 "form-data": "^4.0.0",
                 "got": "^11.8.5",
-                "semver": "^7.3.8",
+                "semver": "~7.6.0",
                 "ws": "^8.18.2"
             },
             "devDependencies": {
@@ -3978,12 +3978,9 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "node_modules/semver": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-            "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -7460,12 +7457,9 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "semver": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-            "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
-            "requires": {
-                "lru-cache": "^6.0.0"
-            }
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
         },
         "send": {
             "version": "0.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
                 "@flowfuse/nr-launcher": "^2.17.0",
                 "form-data": "^4.0.0",
                 "got": "^11.8.5",
-                "semver": "^7.3.8"
+                "semver": "^7.3.8",
+                "ws": "^8.18.2"
             },
             "devDependencies": {
                 "eslint": "^8.25.0",
@@ -4529,9 +4530,9 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "version": "8.18.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+            "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -7887,9 +7888,9 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "ws": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+            "version": "8.18.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+            "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
             "requires": {}
         },
         "xtend": {

--- a/package.json
+++ b/package.json
@@ -21,11 +21,12 @@
     },
     "license": "Apache-2.0",
     "dependencies": {
-        "@flowfuse/nr-launcher": "^2.17.0",
         "@flowfuse/mqtt-schema-agent": "^1.0.0",
+        "@flowfuse/nr-launcher": "^2.17.0",
         "form-data": "^4.0.0",
         "got": "^11.8.5",
-        "semver": "^7.3.8"
+        "semver": "^7.3.8",
+        "ws": "^8.18.2"
     },
     "devDependencies": {
         "eslint": "^8.25.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "@flowfuse/nr-launcher": "^2.17.0",
         "form-data": "^4.0.0",
         "got": "^11.8.5",
-        "semver": "^7.3.8",
+        "semver": "~7.6.0",
         "ws": "^8.18.2"
     },
     "devDependencies": {


### PR DESCRIPTION
part of FlowFuse/flowfuse#5523

## Description

<!-- Describe your changes in detail -->
Adds `resources` API to return historical CPU and process size information

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/flowfuse#5523


## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

